### PR TITLE
Remove Python 3.7-3.9 and add Python 3.10 to Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,17 +31,7 @@ updates:
     schedule:
       interval: weekly
 
-  - directory: /src/py3.7
-    package-ecosystem: pip
-    schedule:
-      interval: weekly
-
-  - directory: /src/py3.8
-    package-ecosystem: pip
-    schedule:
-      interval: weekly
-
-  - directory: /src/py3.9
+  - directory: /src/py3.10
     package-ecosystem: pip
     schedule:
       interval: weekly


### PR DESCRIPTION
## 🗣 Description ##

This pull request removes Python 3.7-3.9 and adds Python 3.10 to the Dependabot configuration.

## 💭 Motivation and context ##

This Lambda only supports Python 3.10 right now.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.